### PR TITLE
Add suboptimal approach to CORS handling

### DIFF
--- a/foundation/web/cors.go
+++ b/foundation/web/cors.go
@@ -1,0 +1,26 @@
+package web
+
+import (
+	"net/http"
+)
+
+// CORS middleware for handling CORS
+// TODO: This feels like it should be in business logic not foundation
+func CORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// Set headers
+		w.Header().Set("Access-Control-Allow-Headers:", "*")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "*")
+
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// Next
+		next.ServeHTTP(w, r)
+		return
+	})
+}

--- a/foundation/web/web.go
+++ b/foundation/web/web.go
@@ -44,6 +44,7 @@ func NewApp(shutdown chan os.Signal, mw ...Middleware) *App {
 		shutdown: shutdown,
 		mw:       mw,
 	}
+	app.mux.Use(CORS)
 
 	return &app
 }
@@ -73,8 +74,12 @@ func (a *App) Handle(verb, path string, params []string, handler Handler, mw ...
 		}
 	}
 
+	// Add OPTIONS to every handler to handle CORS options requests
+	// TODO: this is sneaky and unclear but works, need to find a better way of doing this
+	verbs := []string{verb, http.MethodOptions}
+
 	// Add this handler for the specified verb and route.
-	a.mux.Handle(path, http.HandlerFunc(h)).Methods(verb).Queries()
+	a.mux.Handle(path, http.HandlerFunc(h)).Methods(verbs...).Queries()
 }
 
 // SignalShutdown is used to gracefully shutdown the app when an integrity


### PR DESCRIPTION
This is messy and not inline with how I've built the rest of the middleware but it works while I sort out a better approach. This is also makes things WIDE open in terms of CORS so if we productionize this, we'll need a better way of configuring which domains to allow.